### PR TITLE
Correctly detect, store, and update pull request conflicts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,64 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'observatory'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=observatory"
+                ],
+                "filter": {
+                    "name": "observatory",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'observatory'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=observatory",
+                    "--package=observatory"
+                ],
+                "filter": {
+                    "name": "observatory",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'observatory'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=observatory",
+                    "--package=observatory"
+                ],
+                "filter": {
+                    "name": "observatory",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ dependencies = [
 name = "observatory"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ viz = { version = "0.4.8", features = ["json", "limits"] }
 time = "0.3.19"
 hmac = "0.12.1"
 ring = "0.16.20"
+async-trait = "0.1.64"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 
 use eyre::Result;
 
-use crate::helpers::comments::{CommentHeader, ToMarkdown};
+use crate::helpers::comments::CommentHeader;
 use crate::helpers::pulls::{self, ConflictType};
+use crate::helpers::ToMarkdown;
 use crate::structs::IssueComment;
 use crate::{github, memory, structs};
 
@@ -126,8 +127,10 @@ impl Controller {
                     let mut skip_commenting = false;
                     if let Some(ec) = existing_conflicts.get_mut(&conflict.notification_target) {
                         for i in ec.iter_mut() {
-                            if i.reference_target == conflict.reference_target && i.kind == conflict.kind {
-                                if i.file_set == conflict.file_set  {
+                            if i.reference_target == conflict.reference_target
+                                && i.kind == conflict.kind
+                            {
+                                if i.file_set == conflict.file_set {
                                     skip_commenting = true;
                                 }
                                 i.file_set = conflict.file_set.clone();
@@ -144,7 +147,8 @@ impl Controller {
                         .push(conflict);
                 }
             }
-            self.memory.replace_conflicts(full_repo_name, existing_conflicts);
+            self.memory
+                .replace_conflicts(full_repo_name, existing_conflicts);
         }
         if !trigger_updates {
             return Ok(());

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -140,6 +140,10 @@ impl<T: GitHubInterface> Controller<T> {
                     pending_updates
                         .entry(conflict.notification_target)
                         .or_default()
+                        .push(conflict.clone());
+                    existing_conflicts
+                        .entry(conflict.notification_target)
+                        .or_default()
                         .push(conflict);
                 }
             }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -121,11 +121,9 @@ impl<T: GitHubInterface> Controller<T> {
                 let conflicts = pulls::compare_pulls(&new_pull, &other_pull);
                 for conflict in conflicts {
                     let mut skip_commenting = false;
-                    if let Some(ec) = existing_conflicts.get_mut(&conflict.notification_target) {
+                    if let Some(ec) = existing_conflicts.get_mut(&conflict.trigger) {
                         for i in ec.iter_mut() {
-                            if i.reference_target == conflict.reference_target
-                                && i.kind == conflict.kind
-                            {
+                            if i.original == conflict.original && i.kind == conflict.kind {
                                 if i.file_set == conflict.file_set {
                                     skip_commenting = true;
                                 }
@@ -138,11 +136,11 @@ impl<T: GitHubInterface> Controller<T> {
                         continue;
                     }
                     pending_updates
-                        .entry(conflict.notification_target)
+                        .entry(conflict.trigger)
                         .or_default()
                         .push(conflict.clone());
                     existing_conflicts
-                        .entry(conflict.notification_target)
+                        .entry(conflict.trigger)
                         .or_default()
                         .push(conflict);
                 }
@@ -184,7 +182,7 @@ impl<T: GitHubInterface> Controller<T> {
             }
 
             for u in updates {
-                let key = (u.reference_target, u.kind.clone());
+                let key = (u.original, u.kind.clone());
                 if let Some(existing_comment) = pull_references.get(&key) {
                     if let Err(e) = self
                         .github

--- a/src/controller_test.rs
+++ b/src/controller_test.rs
@@ -1,0 +1,617 @@
+use super::*;
+
+use crate::helpers::pulls::Conflict;
+use crate::test::{self, pull_link};
+
+async fn make_controller(init: bool) -> Controller<test::DummyGitHubClient> {
+    let mut c =
+        Controller::<test::DummyGitHubClient>::new("123".to_string(), "private-key".to_string());
+    if init {
+        c.init().await.unwrap();
+    }
+    c
+}
+
+#[tokio::test]
+async fn test_has_control_over() {
+    let c = make_controller(true).await;
+
+    assert!(c.has_control_over(&structs::Actor {
+        id: 1,
+        login: "test-app[bot]".to_string()
+    }));
+    assert!(!c.has_control_over(&structs::Actor {
+        id: 1,
+        login: "test-app".to_string()
+    }));
+    assert!(!c.has_control_over(&structs::Actor {
+        id: 2,
+        login: "ppy".to_string()
+    }));
+}
+
+#[tokio::test]
+async fn test_add_pull() {
+    let c = make_controller(true).await;
+    let mut p = c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]);
+    p.diff = None;
+    let pn = p.number;
+
+    c.add_pull("test/repo", p, false).await.unwrap();
+
+    let m = c.memory.pulls("test/repo");
+    assert!(m.is_some());
+    assert!(m.unwrap().get(&pn).unwrap().diff.is_some());
+}
+
+#[tokio::test]
+async fn test_simple_existing_change() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls {
+        c.add_pull("test/repo", p, false).await.unwrap();
+    }
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec!["wiki/Article/en.md".to_string()]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_simple_new_original_change() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls {
+        c.add_pull("test/repo", p, false).await.unwrap();
+    }
+
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&1).unwrap(),
+        &vec![Conflict::new_original_change(
+            1,
+            2,
+            pull_link("test/repo", 2),
+            vec!["wiki/Article/en.md".to_string()]
+        )]
+    );
+    assert!(c.memory.conflicts("test/repo").get(&2).is_none());
+}
+
+#[tokio::test]
+async fn test_simple_existing_original_change() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+    ];
+    for p in pulls {
+        c.add_pull("test/repo", p, false).await.unwrap();
+    }
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_original_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec!["wiki/Article/ru.md".to_string()],
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_existing_change_multiple_conflicts() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls {
+        c.add_pull("test/repo", p, false).await.unwrap();
+    }
+
+    let existing_change_conflict = |trigger, original| {
+        Conflict::existing_change(
+            trigger,
+            original,
+            pull_link("test/repo", original),
+            vec!["wiki/Article/en.md".to_string()],
+        )
+    };
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![existing_change_conflict(2, 1)]
+    );
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&3).unwrap(),
+        &vec![
+            existing_change_conflict(3, 1),
+            existing_change_conflict(3, 2),
+        ]
+    );
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&4).unwrap(),
+        &vec![
+            existing_change_conflict(4, 1),
+            existing_change_conflict(4, 2),
+            existing_change_conflict(4, 3),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_new_original_change_multiple_conflicts() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/jp.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ko.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls {
+        c.add_pull("test/repo", p, false).await.unwrap();
+    }
+
+    let new_original_change_conflict = |trigger, original| {
+        Conflict::new_original_change(
+            trigger,
+            original,
+            pull_link("test/repo", original),
+            vec!["wiki/Article/en.md".to_string()],
+        )
+    };
+
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&1).unwrap(),
+        &vec![new_original_change_conflict(1, 4)]
+    );
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![new_original_change_conflict(2, 4)]
+    );
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&3).unwrap(),
+        &vec![new_original_change_conflict(3, 4)]
+    );
+    assert!(c.memory.conflicts("test/repo").get(&4).is_none());
+}
+
+#[tokio::test]
+async fn test_existing_original_change_multiple_conflicts() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/jp.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ko.md"]),
+    ];
+    for p in pulls {
+        c.add_pull("test/repo", p, false).await.unwrap();
+    }
+
+    let existing_original_change_conflict = |trigger, original, language| {
+        Conflict::existing_original_change(
+            trigger,
+            original,
+            pull_link("test/repo", original),
+            vec![format!("wiki/Article/{}.md", language)],
+        )
+    };
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![existing_original_change_conflict(2, 1, "ru")]
+    );
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&3).unwrap(),
+        &vec![existing_original_change_conflict(3, 1, "jp")]
+    );
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&4).unwrap(),
+        &vec![existing_original_change_conflict(4, 1, "ko")]
+    );
+}
+
+#[tokio::test]
+async fn test_existing_change_conflict_update_no_extra_files() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull("test/repo", p.clone(), false).await.unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        1,
+        &["wiki/Article/ru.md", "wiki/Other_article/ru.md"],
+    );
+    c.add_pull("test/repo", pulls[0].clone(), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec!["wiki/Article/ru.md".to_string()]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_existing_change_conflict_update_recognized() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull(
+            "test/repo",
+            &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
+        ),
+    ];
+    for p in pulls.iter() {
+        c.add_pull("test/repo", p.clone(), false).await.unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        1,
+        &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", pulls[0].clone(), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec![
+                "wiki/Article/ru.md".to_string(),
+                "wiki/Other_article/en.md".to_string()
+            ]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_existing_change_conflict_double_update() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        1,
+        &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+        .await
+        .unwrap();
+    c.github.test_update_pull(
+        "test/repo",
+        2,
+        &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec![
+                "wiki/Article/ru.md".to_string(),
+                "wiki/Other_article/en.md".to_string()
+            ]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_new_original_change_conflict_update_no_extra_files() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        2,
+        &["wiki/Article/en.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&2).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&1).unwrap(),
+        &vec![Conflict::new_original_change(
+            1,
+            2,
+            pull_link("test/repo", 2),
+            vec!["wiki/Article/en.md".to_string()]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_new_original_change_conflict_update_recognized() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull(
+            "test/repo",
+            &["wiki/Article/ru.md", "wiki/Other_article/sv.md"],
+        ),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        2,
+        &["wiki/Article/en.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&2).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&1).unwrap(),
+        &vec![Conflict::new_original_change(
+            1,
+            2,
+            pull_link("test/repo", 2),
+            vec![
+                "wiki/Article/en.md".to_string(),
+                "wiki/Other_article/en.md".to_string()
+            ]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_new_original_change_conflict_double_update() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        1,
+        &["wiki/Article/ru.md", "wiki/Other_article/ru.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+        .await
+        .unwrap();
+    c.github.test_update_pull(
+        "test/repo",
+        2,
+        &["wiki/Article/en.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&2).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&1).unwrap(),
+        &vec![Conflict::new_original_change(
+            1,
+            2,
+            pull_link("test/repo", 2),
+            vec![
+                "wiki/Article/en.md".to_string(),
+                "wiki/Other_article/en.md".to_string()
+            ]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_existing_original_change_conflict_update_no_extra_files() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        1,
+        &["wiki/Article/en.md", "wiki/Other_article/en.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_original_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec!["wiki/Article/en.md".to_string()]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_existing_original_change_conflict_update_recognized() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull(
+            "test/repo",
+            &["wiki/Article/en.md", "wiki/Other_article/en.md"],
+        ),
+        c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    c.github.test_update_pull(
+        "test/repo",
+        2,
+        &["wiki/Article/ru.md", "wiki/Other_article/ru.md"],
+    );
+    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+        .await
+        .unwrap();
+
+    assert!(c.memory.conflicts("test/repo").get(&1).is_none());
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&2).unwrap(),
+        &vec![Conflict::existing_original_change(
+            2,
+            1,
+            pull_link("test/repo", 1),
+            vec![
+                "wiki/Article/ru.md".to_string(),
+                "wiki/Other_article/ru.md".to_string()
+            ]
+        )]
+    );
+}
+
+#[tokio::test]
+async fn test_three_conflicts_at_once() {
+    let c = make_controller(true).await;
+    let pulls = [
+        c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
+        c.github
+            .test_add_pull("test/repo", &["wiki/Other_article/ru.md"]),
+        c.github.test_add_pull(
+            "test/repo",
+            &[
+                "wiki/Article/ru.md",
+                "wiki/Other_article/ru.md",
+                "wiki/Different_article/ru.md",
+            ],
+        ),
+        c.github
+            .test_add_pull("test/repo", &["wiki/Different_article/en.md"]),
+    ];
+    for p in pulls.iter() {
+        c.add_pull(
+            "test/repo",
+            c.github.fetch_pull("test/repo", p.number),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(
+        c.memory.conflicts("test/repo").get(&3).unwrap(),
+        &vec![
+            Conflict::existing_original_change(
+                3,
+                1,
+                pull_link("test/repo", 1),
+                vec!["wiki/Article/ru.md".to_string(),]
+            ),
+            Conflict::existing_change(
+                3,
+                2,
+                pull_link("test/repo", 2),
+                vec!["wiki/Other_article/ru.md".to_string(),]
+            ),
+            Conflict::new_original_change(
+                3,
+                4,
+                pull_link("test/repo", 4),
+                vec!["wiki/Different_article/en.md".to_string(),]
+            )
+        ]
+    );
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -44,6 +44,12 @@ impl GitHub {
     pub fn issue_comment(full_repo_name: &str, comment_id: i64) -> String {
         format!("{GITHUB_API_ROOT}/repos/{full_repo_name}/issues/comments/{comment_id}")
     }
+
+    // GitHub.com links
+
+    pub fn pull_url(full_repo_name: &str, pull_number: i32) -> String {
+        format!("{GITHUB_ROOT}/{full_repo_name}/pull/{pull_number}")
+    }
     pub fn diff_url(full_repo_name: &str, pull_number: i32) -> String {
         // Diff links are handled by github.com, not the API subdomain.
         format!("{GITHUB_ROOT}/{full_repo_name}/pull/{pull_number}.diff")

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,11 +1,11 @@
 use viz::IntoResponse;
 use viz::{Request, RequestExt, StatusCode};
 
-use crate::{controller, structs};
+use crate::{controller, github, structs};
 
 pub async fn pull_request_event(req: Request, body: String) -> viz::Result<()> {
     let controller = req
-        .state::<controller::Controller>()
+        .state::<controller::Controller<github::Client>>()
         .ok_or_else(|| StatusCode::INTERNAL_SERVER_ERROR.into_error())?;
 
     let evt: structs::PullRequestEvent = serde_json::from_str(&body).map_err(|e| {
@@ -42,7 +42,7 @@ pub async fn pull_request_event(req: Request, body: String) -> viz::Result<()> {
 
 pub async fn installation_event(req: Request, body: String) -> viz::Result<()> {
     let controller = req
-        .state::<controller::Controller>()
+        .state::<controller::Controller<github::Client>>()
         .ok_or_else(|| StatusCode::INTERNAL_SERVER_ERROR.into_error())?;
 
     let evt: structs::InstallationEvent = serde_json::from_str(&body).map_err(|e| {

--- a/src/helpers/comments.rs
+++ b/src/helpers/comments.rs
@@ -40,7 +40,7 @@ pub struct CommentHeader {
 impl CommentHeader {
     /// Attempt to extract the header from a Markdown comment.
     /// The header is expected to look like this, with HTML comment tags on separate lines:
-    /// ```
+    /// ```ignore
     /// <!--
     ///   key1: value1
     ///   key2: value2

--- a/src/helpers/comments_test.rs
+++ b/src/helpers/comments_test.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+#[test]
+fn to_markdown() {
+    let hdr = CommentHeader {
+        pull_number: 12,
+        conflict_type: ConflictType::ExistingChange,
+    };
+    assert_eq!(
+        hdr.to_markdown(),
+        r#"<!--
+pull_number: 12
+conflict_type: ExistingChange
+-->"#
+    );
+}
+
+#[test]
+fn from_comment_without_header() {
+    let comment = "test comment";
+    assert_eq!(CommentHeader::from_comment(comment), None);
+}
+
+#[test]
+fn from_comment_with_bad_header() {
+    let c1 = r#"<!--
+test comment"#;
+    assert_eq!(CommentHeader::from_comment(c1), None);
+
+    let c2 = r#"<!--
+pull_number: 12
+some shit
+conflict_type: ExistingChange
+"#;
+    assert_eq!(CommentHeader::from_comment(c2), None);
+}
+
+#[test]
+fn from_comment_ok() {
+    let comment = r#"<!--
+pull_number: 12
+conflict_type: ExistingOriginalChange
+-->
+Some text here."#;
+    assert_eq!(
+        CommentHeader::from_comment(comment),
+        Some(CommentHeader {
+            pull_number: 12,
+            conflict_type: ConflictType::ExistingOriginalChange
+        })
+    );
+}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,2 +1,6 @@
 pub mod comments;
 pub mod pulls;
+
+pub trait ToMarkdown {
+    fn to_markdown(&self) -> String;
+}

--- a/src/helpers/pulls.rs
+++ b/src/helpers/pulls.rs
@@ -22,16 +22,16 @@ pub enum ConflictType {
 }
 
 /// A structure containing information about a conflict between two pull requests.
-#[derive(Debug, Ord, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Ord, Eq, PartialEq, PartialOrd, Clone)]
 pub struct Conflict {
     /// Type of conflict.
     pub kind: ConflictType,
 
-    /// The pull request which will be notified. Typically its author will need to follow the reference pull for changes,
-    /// and resolve conflicts.
+    /// The pull request which triggered the conflict and will be notified.
+    /// Typically its author will need to follow the referenced pull for changes, and resolve conflicts.
     pub notification_target: i32,
 
-    /// The pull request which triggered the conflict. It is assumed to have higher priority (the other party will need to adjust).
+    /// The pull request which is considered original. It is assumed to have higher priority (the other party will need to adjust).
     pub reference_target: i32,
 
     /// A GitHub URL to the "original" pull request.

--- a/src/helpers/pulls_test.rs
+++ b/src/helpers/pulls_test.rs
@@ -1,0 +1,226 @@
+use std::str::FromStr;
+
+use crate::structs::PullRequest;
+
+use super::*;
+
+fn make_simple_diff(file_names: &[&str]) -> unidiff::PatchSet {
+    let diff: Vec<String> = file_names
+        .iter()
+        .map(|file_name| {
+            format!(
+                r#"diff --git a/{0} b/{1}
+index 5483f282a0a..2c8c1482b97 100644
+--- a/{0}
++++ b/{1}
+@@ -5,6 +5,7 @@
+ 
+ ## Test article
+ 
++<!-- test -->
+ Do whatever you want.
+ 
+ That's it, that's the article."#,
+                file_name, file_name
+            )
+        })
+        .collect();
+    unidiff::PatchSet::from_str(&diff.join("\n")).unwrap()
+}
+
+fn make_pull(pull_number: i32, file_names: &[&str]) -> PullRequest {
+    let now = chrono::Utc::now();
+    structs::PullRequest {
+        id: pull_number as i64,
+        number: pull_number,
+        state: "open".to_string(),
+        title: "Update `Ranking criteria`".to_string(),
+        user: structs::Actor {
+            id: 1,
+            login: "BanchoBot".to_string(),
+        },
+        html_url: format!("https://github.com/test/repo/pull/{}", pull_number),
+        created_at: now,
+        updated_at: now,
+        diff: Some(make_simple_diff(file_names)),
+    }
+}
+
+#[test]
+fn conflict_to_markdown() {
+    let c1 = Conflict {
+        kind: ConflictType::ExistingChange,
+        notification_target: 1,
+        reference_target: 2,
+        reference_url: "https://github.com/test/repo/pull/2".to_string(),
+        file_set: vec!["wiki/Ranking_criteria/en.md".to_string()],
+    };
+    assert_eq!(
+        c1.to_markdown(),
+        format!(
+            r#"<!--
+pull_number: 2
+conflict_type: ExistingChange
+-->
+{}
+- https://github.com/test/repo/pull/2, files:
+  ```
+  wiki/Ranking_criteria/en.md
+  ```"#,
+            comments::EXISTING_CHANGE_TEMPLATE
+        )
+    );
+
+    let c2 = Conflict {
+        kind: ConflictType::NewOriginalChange,
+        notification_target: 2,
+        reference_target: 3,
+        reference_url: "https://github.com/test/repo/pull/3".to_string(),
+        file_set: vec!["wiki/Ranking_criteria/en.md".to_string(); 11],
+    };
+    assert_eq!(
+        c2.to_markdown(),
+        format!(
+            r#"<!--
+pull_number: 3
+conflict_type: NewOriginalChange
+-->
+{}
+- https://github.com/test/repo/pull/3 (>10 files)"#,
+            comments::NEW_ORIGINAL_CHANGE_TEMPLATE
+        )
+    );
+}
+
+#[test]
+fn article_basic() {
+    let original = Article::from_file_path("wiki/Article/en.md");
+    assert!(original.is_original());
+    assert!(!original.is_translation());
+    assert_eq!(original.language, "en");
+    assert_eq!(original.path, "wiki/Article");
+    assert_eq!(original.file_path(), "wiki/Article/en.md");
+
+    let translation = Article::from_file_path("wiki/Article/ko.md");
+    assert!(!translation.is_original());
+    assert!(translation.is_translation());
+    assert_eq!(translation.language, "ko");
+    assert_eq!(translation.path, "wiki/Article");
+    assert_eq!(translation.file_path(), "wiki/Article/ko.md");
+
+    assert_ne!(original, translation);
+}
+
+#[test]
+fn different_paths_no_conflict() {
+    let existing_pull = make_pull(1, &["wiki/First_article/en.md"]);
+    let new_pull = make_pull(2, &["wiki/Second_article/en.md"]);
+    assert!(compare_pulls(&new_pull, &existing_pull).is_empty());
+}
+
+#[test]
+fn no_markdown_no_conflict() {
+    let existing_pull = make_pull(1, &["wiki/First_article/img/test.png"]);
+    let new_pull = make_pull(2, &["wiki/First_article/img/test.png"]);
+    assert!(compare_pulls(&new_pull, &existing_pull).is_empty());
+}
+
+#[test]
+fn single_file_existing_change() {
+    let existing_pull = make_pull(1, &["wiki/Article/en.md"]);
+    let new_pull = make_pull(2, &["wiki/Article/en.md"]);
+
+    assert_eq!(
+        compare_pulls(&new_pull, &existing_pull),
+        vec![Conflict {
+            kind: ConflictType::ExistingChange,
+            notification_target: 2,
+            reference_target: 1,
+            reference_url: "https://github.com/test/repo/pull/1".to_string(),
+            file_set: vec!["wiki/Article/en.md".to_string()],
+        }]
+    );
+}
+
+#[test]
+fn multiple_files_existing_change() {
+    let existing_pull = make_pull(
+        1,
+        &[
+            "wiki/Article/en.md",
+            "wiki/Ranking_criteria/en.md",
+            "wiki/Article/img/test.png",
+            "wiki/Unrelated_article/ru.md",
+        ],
+    );
+    let new_pull = make_pull(
+        2,
+        &[
+            "wiki/Ranking_criteria/en.md",
+            "wiki/Article/en.md",
+            "wiki/Some_other_article/en.md",
+            "wiki/Test_article/en.md",
+        ],
+    );
+
+    assert_eq!(
+        compare_pulls(&new_pull, &existing_pull),
+        vec![Conflict {
+            kind: ConflictType::ExistingChange,
+            notification_target: 2,
+            reference_target: 1,
+            reference_url: "https://github.com/test/repo/pull/1".to_string(),
+            file_set: vec![
+                "wiki/Article/en.md".to_string(),
+                "wiki/Ranking_criteria/en.md".to_string(),
+            ],
+        }]
+    );
+    assert_eq!(
+        compare_pulls(&existing_pull, &new_pull),
+        vec![Conflict {
+            kind: ConflictType::ExistingChange,
+            notification_target: 1,
+            reference_target: 2,
+            reference_url: "https://github.com/test/repo/pull/2".to_string(),
+            file_set: vec![
+                "wiki/Article/en.md".to_string(),
+                "wiki/Ranking_criteria/en.md".to_string(),
+            ],
+        }]
+    );
+}
+
+#[test]
+fn existing_translation_new_original_change() {
+    let existing_pull = make_pull(1, &["wiki/Article/ru.md"]);
+    let new_pull = make_pull(2, &["wiki/Article/en.md"]);
+
+    assert_eq!(
+        compare_pulls(&new_pull, &existing_pull),
+        vec![Conflict {
+            kind: ConflictType::NewOriginalChange,
+            notification_target: 1,
+            reference_target: 2,
+            reference_url: "https://github.com/test/repo/pull/2".to_string(),
+            file_set: vec!["wiki/Article/en.md".to_string(),],
+        }]
+    );
+}
+
+#[test]
+fn new_translation_existing_original_change() {
+    let existing_pull = make_pull(1, &["wiki/Article/en.md"]);
+    let new_pull = make_pull(2, &["wiki/Article/ru.md"]);
+
+    assert_eq!(
+        compare_pulls(&new_pull, &existing_pull),
+        vec![Conflict {
+            kind: ConflictType::ExistingOriginalChange,
+            notification_target: 2,
+            reference_target: 1,
+            reference_url: "https://github.com/test/repo/pull/1".to_string(),
+            file_set: vec!["wiki/Article/ru.md".to_string(),],
+        }]
+    );
+}

--- a/src/helpers/pulls_test.rs
+++ b/src/helpers/pulls_test.rs
@@ -1,32 +1,7 @@
-use std::str::FromStr;
-
-use crate::structs::PullRequest;
-
 use super::*;
 
-fn make_simple_diff(file_names: &[&str]) -> unidiff::PatchSet {
-    let diff: Vec<String> = file_names
-        .iter()
-        .map(|file_name| {
-            format!(
-                r#"diff --git a/{0} b/{1}
-index 5483f282a0a..2c8c1482b97 100644
---- a/{0}
-+++ b/{1}
-@@ -5,6 +5,7 @@
- 
- ## Test article
- 
-+<!-- test -->
- Do whatever you want.
- 
- That's it, that's the article."#,
-                file_name, file_name
-            )
-        })
-        .collect();
-    unidiff::PatchSet::from_str(&diff.join("\n")).unwrap()
-}
+use crate::structs::PullRequest;
+use crate::test;
 
 fn make_pull(pull_number: i32, file_names: &[&str]) -> PullRequest {
     let now = chrono::Utc::now();
@@ -42,7 +17,7 @@ fn make_pull(pull_number: i32, file_names: &[&str]) -> PullRequest {
         html_url: format!("https://github.com/test/repo/pull/{}", pull_number),
         created_at: now,
         updated_at: now,
-        diff: Some(make_simple_diff(file_names)),
+        diff: Some(test::make_simple_diff(file_names)),
     }
 }
 

--- a/src/helpers/pulls_test.rs
+++ b/src/helpers/pulls_test.rs
@@ -23,13 +23,12 @@ fn make_pull(pull_number: i32, file_names: &[&str]) -> PullRequest {
 
 #[test]
 fn conflict_to_markdown() {
-    let c1 = Conflict {
-        kind: ConflictType::ExistingChange,
-        notification_target: 1,
-        reference_target: 2,
-        reference_url: "https://github.com/test/repo/pull/2".to_string(),
-        file_set: vec!["wiki/Ranking_criteria/en.md".to_string()],
-    };
+    let c1 = Conflict::existing_change(
+        1,
+        2,
+        "https://github.com/test/repo/pull/2".to_string(),
+        vec!["wiki/Ranking_criteria/en.md".to_string()],
+    );
     assert_eq!(
         c1.to_markdown(),
         format!(
@@ -46,13 +45,12 @@ conflict_type: ExistingChange
         )
     );
 
-    let c2 = Conflict {
-        kind: ConflictType::NewOriginalChange,
-        notification_target: 2,
-        reference_target: 3,
-        reference_url: "https://github.com/test/repo/pull/3".to_string(),
-        file_set: vec!["wiki/Ranking_criteria/en.md".to_string(); 11],
-    };
+    let c2 = Conflict::new_original_change(
+        2,
+        3,
+        "https://github.com/test/repo/pull/3".to_string(),
+        vec!["wiki/Ranking_criteria/en.md".to_string(); 11],
+    );
     assert_eq!(
         c2.to_markdown(),
         format!(
@@ -107,13 +105,12 @@ fn single_file_existing_change() {
 
     assert_eq!(
         compare_pulls(&new_pull, &existing_pull),
-        vec![Conflict {
-            kind: ConflictType::ExistingChange,
-            notification_target: 2,
-            reference_target: 1,
-            reference_url: "https://github.com/test/repo/pull/1".to_string(),
-            file_set: vec!["wiki/Article/en.md".to_string()],
-        }]
+        vec![Conflict::existing_change(
+            2,
+            1,
+            "https://github.com/test/repo/pull/1".to_string(),
+            vec!["wiki/Article/en.md".to_string()],
+        )]
     );
 }
 
@@ -140,29 +137,27 @@ fn multiple_files_existing_change() {
 
     assert_eq!(
         compare_pulls(&new_pull, &existing_pull),
-        vec![Conflict {
-            kind: ConflictType::ExistingChange,
-            notification_target: 2,
-            reference_target: 1,
-            reference_url: "https://github.com/test/repo/pull/1".to_string(),
-            file_set: vec![
+        vec![Conflict::existing_change(
+            2,
+            1,
+            "https://github.com/test/repo/pull/1".to_string(),
+            vec![
                 "wiki/Article/en.md".to_string(),
                 "wiki/Ranking_criteria/en.md".to_string(),
-            ],
-        }]
+            ]
+        )]
     );
     assert_eq!(
         compare_pulls(&existing_pull, &new_pull),
-        vec![Conflict {
-            kind: ConflictType::ExistingChange,
-            notification_target: 1,
-            reference_target: 2,
-            reference_url: "https://github.com/test/repo/pull/2".to_string(),
-            file_set: vec![
+        vec![Conflict::existing_change(
+            1,
+            2,
+            "https://github.com/test/repo/pull/2".to_string(),
+            vec![
                 "wiki/Article/en.md".to_string(),
                 "wiki/Ranking_criteria/en.md".to_string(),
-            ],
-        }]
+            ]
+        )]
     );
 }
 
@@ -173,13 +168,12 @@ fn existing_translation_new_original_change() {
 
     assert_eq!(
         compare_pulls(&new_pull, &existing_pull),
-        vec![Conflict {
-            kind: ConflictType::NewOriginalChange,
-            notification_target: 1,
-            reference_target: 2,
-            reference_url: "https://github.com/test/repo/pull/2".to_string(),
-            file_set: vec!["wiki/Article/en.md".to_string(),],
-        }]
+        vec![Conflict::new_original_change(
+            1,
+            2,
+            "https://github.com/test/repo/pull/2".to_string(),
+            vec!["wiki/Article/en.md".to_string(),],
+        )]
     );
 }
 
@@ -190,12 +184,11 @@ fn new_translation_existing_original_change() {
 
     assert_eq!(
         compare_pulls(&new_pull, &existing_pull),
-        vec![Conflict {
-            kind: ConflictType::ExistingOriginalChange,
-            notification_target: 2,
-            reference_target: 1,
-            reference_url: "https://github.com/test/repo/pull/1".to_string(),
-            file_set: vec!["wiki/Article/ru.md".to_string(),],
-        }]
+        vec![Conflict::existing_original_change(
+            2,
+            1,
+            "https://github.com/test/repo/pull/1".to_string(),
+            vec!["wiki/Article/ru.md".to_string(),],
+        )]
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,6 @@ pub mod handler;
 pub mod helpers;
 pub mod memory;
 pub mod structs;
+
+#[cfg(test)]
+pub(crate) mod test;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use viz::IntoResponse;
 use viz::{types::State, Router, Server, ServiceMaker};
 use viz::{Request, RequestExt, StatusCode};
 
-use observatory::{config, controller, handler};
+use observatory::{config, controller, github, handler};
 
 #[derive(Parser, Debug)]
 #[command(version)]
@@ -130,7 +130,8 @@ async fn main() -> Result<()> {
     let webhook_secret = settings.github.webhook_secret;
 
     let validator = RequestValidator::new(webhook_secret);
-    let mut controller = controller::Controller::new(settings.github.app_id, private_key);
+    let mut controller =
+        controller::Controller::<github::Client>::new(settings.github.app_id, private_key);
     controller.init().await?;
     log::info!("Active installations: {:?}", controller.installations());
     log::debug!("GitHub App: {:?}", controller.app);

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -75,8 +75,11 @@ impl Memory {
     }
 
     pub fn replace_conflicts(&self, full_repo_name: &str, conflicts: HashMap<i32, Vec<Conflict>>) {
-        self.conflicts.lock().unwrap().insert(full_repo_name.to_string(), conflicts);
-    }   
+        self.conflicts
+            .lock()
+            .unwrap()
+            .insert(full_repo_name.to_string(), conflicts);
+    }
 
     pub fn drop_repository(&self, full_repo_name: &str) {
         self.pulls

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -3,12 +3,14 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use crate::helpers::pulls::Conflict;
 use crate::structs::*;
 
 /// The two-level pull request storage (repository -> pull number -> pull object)
 #[derive(Default, Debug, Clone)]
 pub struct Memory {
     pub pulls: Arc<Mutex<HashMap<String, HashMap<i32, PullRequest>>>>,
+    pub conflicts: Arc<Mutex<HashMap<String, HashMap<i32, Vec<Conflict>>>>>,
 }
 
 impl Memory {
@@ -16,7 +18,18 @@ impl Memory {
         Self::default()
     }
 
-    pub fn insert(&self, full_repo_name: &str, new_pull: PullRequest) {
+    pub fn add_conflicts(&self, full_repo_name: &str, pull_number: i32, conflicts: Vec<Conflict>) {
+        self.conflicts
+            .lock()
+            .unwrap()
+            .entry(full_repo_name.to_string())
+            .or_default()
+            .entry(pull_number)
+            .or_default()
+            .extend(conflicts)
+    }
+
+    pub fn insert_pull(&self, full_repo_name: &str, new_pull: PullRequest) {
         let mut g = self.pulls.lock().unwrap();
         if let Some(pull) = g
             .entry(full_repo_name.to_string())
@@ -32,14 +45,45 @@ impl Memory {
             .insert(new_pull.number, new_pull);
     }
 
-    pub fn remove(&self, full_repo_name: &str, p: &PullRequest) {
+    pub fn remove_pull(&self, full_repo_name: &str, p: &PullRequest) {
         if let Some(pulls) = self.pulls.lock().unwrap().get_mut(full_repo_name) {
             pulls.remove(&p.number);
         }
+        if let Some(conflicts) = self.conflicts.lock().unwrap().get_mut(full_repo_name) {
+            conflicts.remove(&p.number);
+        }
     }
+
+    pub fn pulls(&self, full_repo_name: &str) -> Option<HashMap<i32, PullRequest>> {
+        self.pulls
+            .lock()
+            .unwrap()
+            .get(&full_repo_name.to_string())
+            .map(|m| m.clone())
+    }
+
+    pub fn conflicts(&self, full_repo_name: &str) -> HashMap<i32, Vec<Conflict>> {
+        match self
+            .conflicts
+            .lock()
+            .unwrap()
+            .get(&full_repo_name.to_string())
+        {
+            Some(cc) => cc.clone(),
+            None => HashMap::new(),
+        }
+    }
+
+    pub fn replace_conflicts(&self, full_repo_name: &str, conflicts: HashMap<i32, Vec<Conflict>>) {
+        self.conflicts.lock().unwrap().insert(full_repo_name.to_string(), conflicts);
+    }   
 
     pub fn drop_repository(&self, full_repo_name: &str) {
         self.pulls
+            .lock()
+            .unwrap()
+            .remove(&full_repo_name.to_string());
+        self.conflicts
             .lock()
             .unwrap()
             .remove(&full_repo_name.to_string());

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -90,7 +90,7 @@ pub struct InstallationRepositories {
 }
 
 // https://docs.github.com/en/rest/issues/comments#list-issue-comments
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct IssueComment {
     pub id: i64,
     pub body: String,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,234 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use eyre::Result;
+
+use crate::github;
+use crate::structs;
+
+pub fn make_simple_diff(file_names: &[&str]) -> unidiff::PatchSet {
+    let diff: Vec<String> = file_names
+        .iter()
+        .map(|file_name| {
+            format!(
+                r#"diff --git a/{0} b/{1}
+index 5483f282a0a..2c8c1482b97 100644
+--- a/{0}
++++ b/{1}
+@@ -5,6 +5,7 @@
+ 
+ ## Test article
+ 
++<!-- test -->
+ Do whatever you want.
+ 
+ That's it, that's the article."#,
+                file_name, file_name
+            )
+        })
+        .collect();
+    unidiff::PatchSet::from_str(&diff.join("\n")).unwrap()
+}
+
+pub struct DummyGitHubClient {
+    app_id: String,
+
+    // Github mock information
+    installations: Arc<Mutex<HashMap<i64, structs::Installation>>>,
+    last_pull_id: Arc<Mutex<i64>>,
+    pulls: Arc<Mutex<HashMap<String, Vec<structs::PullRequest>>>>,
+    last_comment_id: Arc<Mutex<i64>>,
+    comments: Arc<Mutex<HashMap<String, HashMap<i32, Vec<structs::IssueComment>>>>>,
+}
+
+#[async_trait]
+impl github::GitHubInterface for DummyGitHubClient {
+    fn new(app_id: String, _key: String) -> Self {
+        Self {
+            app_id,
+            installations: Arc::default(),
+            last_pull_id: Arc::new(Mutex::new(1)),
+            pulls: Arc::default(),
+            last_comment_id: Arc::new(Mutex::new(1)),
+            comments: Arc::default(),
+        }
+    }
+
+    async fn installations(&self) -> Result<Vec<structs::Installation>> {
+        Ok(self.cached_installations())
+    }
+
+    fn cached_installations(&self) -> Vec<structs::Installation> {
+        self.installations
+            .lock()
+            .unwrap()
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    // TODO: set repositories?
+    async fn discover_installations(&self) -> Result<Vec<structs::Installation>> {
+        Ok(self.cached_installations())
+    }
+
+    async fn app(&self) -> Result<structs::App> {
+        Ok(structs::App {
+            id: self.app_id.parse().unwrap(),
+            slug: "test-app".to_string(),
+            owner: structs::Actor {
+                id: 1,
+                login: "test-owner".to_string(),
+            },
+            name: "Test GitHub app".to_string(),
+        })
+    }
+
+    // TODO: set repositories?
+    async fn add_installation(
+        &self,
+        installation: structs::Installation,
+    ) -> Result<structs::Installation> {
+        self.installations
+            .lock()
+            .unwrap()
+            .insert(installation.id, installation.clone());
+        Ok(installation)
+    }
+
+    fn remove_installation(&self, installation: &structs::Installation) {
+        self.installations.lock().unwrap().remove(&installation.id);
+    }
+
+    async fn pulls(&self, full_repo_name: &str) -> Result<Vec<structs::PullRequest>> {
+        match self.pulls.lock().unwrap().get(&full_repo_name.to_string()) {
+            Some(v) => Ok(v.clone()),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    async fn post_comment(
+        &self,
+        full_repo_name: &str,
+        issue_number: i32,
+        body: String,
+    ) -> Result<()> {
+        let now = chrono::Utc::now();
+        let mut last_comment_id = self.last_comment_id.lock().unwrap();
+
+        let mut guard = self.comments.lock().unwrap();
+        let pull_comments = guard
+            .entry(full_repo_name.to_string())
+            .or_default()
+            .entry(issue_number)
+            .or_default();
+        pull_comments.push(structs::IssueComment {
+            id: *last_comment_id,
+            body,
+            user: structs::Actor {
+                id: 1,
+                login: "test-app[bot]".to_string(),
+            },
+            created_at: now,
+            updated_at: now,
+        });
+
+        *last_comment_id += 1;
+        Ok(())
+    }
+
+    async fn update_comment(
+        &self,
+        full_repo_name: &str,
+        comment_id: i64,
+        body: String,
+    ) -> Result<()> {
+        if let Some(comments) = self.comments.lock().unwrap().get_mut(full_repo_name) {
+            for pull_comments in comments.values_mut() {
+                for c in pull_comments.iter_mut() {
+                    if c.id == comment_id {
+                        c.body = body;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        eyre::bail!("no comment {} found", comment_id);
+    }
+
+    async fn list_comments(
+        &self,
+        full_repo_name: &str,
+        issue_number: i32,
+    ) -> Result<Vec<structs::IssueComment>> {
+        if let Some(comments) = self.comments.lock().unwrap().get(full_repo_name) {
+            if let Some(pull_comments) = comments.get(&issue_number) {
+                return Ok(pull_comments.clone());
+            }
+        }
+        Ok(Vec::new())
+    }
+
+    async fn read_pull_diff(
+        &self,
+        full_repo_name: &str,
+        pull_number: i32,
+    ) -> Result<unidiff::PatchSet> {
+        if let Some(pulls) = self.pulls.lock().unwrap().get(full_repo_name) {
+            for p in pulls.iter().filter(|p_| p_.number == pull_number) {
+                if let Some(diff) = &p.diff {
+                    return Ok(diff.clone());
+                }
+            }
+        }
+        eyre::bail!("no diff found for pull {}", pull_number);
+    }
+}
+
+impl DummyGitHubClient {
+    pub fn test_add_pull(&self, full_repo_name: &str, file_names: &[&str]) -> structs::PullRequest {
+        let now = chrono::Utc::now();
+        let mut last_pull_id = self.last_pull_id.lock().unwrap();
+        let pull = structs::PullRequest {
+            id: *last_pull_id,
+            number: *last_pull_id as i32,
+            state: "open".to_string(),
+            title: "[FI] Update `Rules`".to_string(),
+            user: structs::Actor {
+                id: 1,
+                login: "LunaticMara".to_string(),
+            },
+            html_url: format!(
+                "https://github.com/{}/pull/{}",
+                full_repo_name, *last_pull_id
+            ),
+            created_at: now,
+            updated_at: now,
+            diff: Some(make_simple_diff(file_names)),
+        };
+        *last_pull_id += 1;
+        self.pulls
+            .lock()
+            .unwrap()
+            .entry(full_repo_name.to_string())
+            .or_default()
+            .push(pull.clone());
+        pull
+    }
+
+    pub fn test_replace_diff(&self, full_repo_name: &str, pull_number: i32, file_names: &[&str]) {
+        for p in self
+            .pulls
+            .lock()
+            .unwrap()
+            .entry(full_repo_name.to_string())
+            .or_default()
+        {
+            if p.number == pull_number {
+                p.diff = Some(make_simple_diff(file_names));
+            }
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -223,7 +223,7 @@ impl DummyGitHubClient {
         pull
     }
 
-    pub fn test_replace_diff(&self, full_repo_name: &str, pull_number: i32, file_names: &[&str]) {
+    pub fn test_update_pull(&self, full_repo_name: &str, pull_number: i32, file_names: &[&str]) {
         for p in self
             .pulls
             .lock()
@@ -233,7 +233,25 @@ impl DummyGitHubClient {
         {
             if p.number == pull_number {
                 p.diff = Some(make_simple_diff(file_names));
+                p.updated_at = chrono::Utc::now();
+                return;
             }
         }
+        panic!("no pull #{pull_number}");
+    }
+
+    pub fn fetch_pull(&self, full_repo_name: &str, pull_number: i32) -> structs::PullRequest {
+        for p in self
+            .pulls
+            .lock()
+            .unwrap()
+            .entry(full_repo_name.to_string())
+            .or_default()
+        {
+            if p.number == pull_number {
+                return p.clone();
+            }
+        }
+        panic!("no pull #{pull_number}");
     }
 }


### PR DESCRIPTION
fixes cases such as below:

```
-   open P1 (Article/en.md)
-   open P2 (Article/en.md) ← conflict detected, attributed to P2 (ok)
- update P1 (Article/en.md) ← conflict detected, attributed to P1 (wrong)
```
