### PR TITLE
Remove obsolete conflicts and delete related comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "observatory"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observatory"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/github.rs
+++ b/src/github.rs
@@ -167,6 +167,7 @@ pub trait GitHubInterface {
         comment_id: i64,
         body: String,
     ) -> Result<()>;
+    async fn delete_comment(&self, full_repo_name: &str, comment_id: i64) -> Result<()>;
     async fn list_comments(
         &self,
         full_repo_name: &str,
@@ -549,6 +550,16 @@ impl GitHubInterface for Client {
             .body(comment)
             .bearer_auth(token);
         __json::<structs::IssueComment>(req).await?;
+        Ok(())
+    }
+
+    async fn delete_comment(&self, full_repo_name: &str, comment_id: i64) -> Result<()> {
+        let token = self.pick_token(full_repo_name).await?;
+        let req = self
+            .http_client
+            .delete(GitHub::issue_comment(full_repo_name, comment_id))
+            .bearer_auth(token);
+        __text(req).await?;
         Ok(())
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -188,6 +188,24 @@ impl github::GitHubInterface for DummyGitHubClient {
         eyre::bail!("no comment {} found", comment_id);
     }
 
+    async fn delete_comment(&self, full_repo_name: &str, comment_id: i64) -> Result<()> {
+        let mut found = false;
+        if let Some(comments) = self.comments.lock().unwrap().get_mut(full_repo_name) {
+            for comments_per_pull in comments.values_mut() {
+                comments_per_pull.retain(|c| {
+                    if c.id == comment_id {
+                        found = true;
+                    }
+                    c.id != comment_id
+                });
+            }
+        }
+        if !found {
+            eyre::bail!("no comment {} found", comment_id);
+        }
+        Ok(())
+    }
+
     async fn list_comments(
         &self,
         full_repo_name: &str,


### PR DESCRIPTION
(this will cause conflict to be attributed to the originally "innocent" PR when it reoccurs, and is for now intended)

closes https://github.com/TicClick/observatory/issues/2