### PR TITLE
Prevent race condition during merges by only updating known pulls

### DIFF
--- a/src/controller/controller_impl.rs
+++ b/src/controller/controller_impl.rs
@@ -68,7 +68,7 @@ impl<T: GitHubInterface> Controller<T> {
                 trigger_updates,
             } => {
                 let pull_number = pull_request.number;
-                self.add_pull(&full_repo_name, *pull_request, trigger_updates)
+                self.upsert_pull(&full_repo_name, *pull_request, trigger_updates)
                     .await
                     .unwrap_or_else(|e| {
                         log::error!(
@@ -195,7 +195,7 @@ impl<T: GitHubInterface> Controller<T> {
     /// Add a repository and fetch its pull requests.
     async fn add_repository(&self, r: &Repository) -> Result<()> {
         for p in self.github.pulls(&r.full_name).await? {
-            self.add_pull(&r.full_name, p, false).await?;
+            self.upsert_pull(&r.full_name, p, false).await?;
         }
         Ok(())
     }
@@ -238,7 +238,7 @@ impl<T: GitHubInterface> Controller<T> {
         trigger_updates: bool,
     ) -> Result<()> {
         if self.memory.contains(full_repo_name, &new_pull) {
-            self.add_pull(full_repo_name, new_pull, trigger_updates)
+            self.upsert_pull(full_repo_name, new_pull, trigger_updates)
                 .await
         } else {
             log::info!(
@@ -254,7 +254,7 @@ impl<T: GitHubInterface> Controller<T> {
     ///
     /// If `trigger_updates` is set, check if the update conflicts with existing pull requests,
     /// and make its author aware (or other PRs' owners, in rare cases). For details, see [`helpers::conflicts::Storage`].
-    async fn add_pull(
+    async fn upsert_pull(
         &self,
         full_repo_name: &str,
         mut new_pull: PullRequest,

--- a/src/controller/controller_impl.rs
+++ b/src/controller/controller_impl.rs
@@ -62,13 +62,30 @@ impl<T: GitHubInterface> Controller<T> {
                 reply_to.send(self.init().await).unwrap();
             }
 
-            ControllerRequest::PullRequestUpdated {
+            ControllerRequest::PullRequestCreated {
                 full_repo_name,
                 pull_request,
                 trigger_updates,
             } => {
                 let pull_number = pull_request.number;
                 self.add_pull(&full_repo_name, *pull_request, trigger_updates)
+                    .await
+                    .unwrap_or_else(|e| {
+                        log::error!(
+                            "Pull #{}: failed to add information and trigger comments: {:?}",
+                            pull_number,
+                            e
+                        );
+                    })
+            }
+
+            ControllerRequest::PullRequestUpdated {
+                full_repo_name,
+                pull_request,
+                trigger_updates,
+            } => {
+                let pull_number = pull_request.number;
+                self.update_pull(&full_repo_name, *pull_request, trigger_updates)
                     .await
                     .unwrap_or_else(|e| {
                         log::error!(
@@ -212,6 +229,24 @@ impl<T: GitHubInterface> Controller<T> {
         self.memory.remove_pull(full_repo_name, &closed_pull);
         self.conflicts
             .remove_conflicts_by_pull(full_repo_name, closed_pull.number);
+    }
+
+    async fn update_pull(
+        &self,
+        full_repo_name: &str,
+        new_pull: PullRequest,
+        trigger_updates: bool,
+    ) -> Result<()> {
+        if self.memory.contains(full_repo_name, &new_pull) {
+            self.add_pull(full_repo_name, new_pull, trigger_updates)
+                .await
+        } else {
+            log::info!(
+                "Pull #{} can't be updated because it wasn't added in the first place",
+                new_pull.number
+            );
+            Ok(())
+        }
     }
 
     /// Handle pull request changes. This includes fetching a `.diff` file from another GitHub domain,

--- a/src/controller/controller_impl/tests/tests_comments.rs
+++ b/src/controller/controller_impl/tests/tests_comments.rs
@@ -6,7 +6,7 @@ use crate::helpers::{comments::CommentHeader, conflicts::ConflictType};
 async fn test_no_conflict_no_comment() {
     let c = new_controller(true).await;
     let p1 = c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]);
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", p1.number),
         true,
@@ -27,14 +27,14 @@ async fn test_one_conflict_one_comment() {
     let p1 = c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]);
     let p2 = c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]);
 
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", p1.number),
         true,
     )
     .await
     .unwrap();
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", p2.number),
         true,
@@ -65,7 +65,7 @@ async fn test_one_conflict_one_valid_header() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -100,7 +100,7 @@ async fn test_one_pull_and_conflict_one_comment() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -114,7 +114,7 @@ async fn test_one_pull_and_conflict_one_comment() {
         pulls[0].number,
         &["wiki/Article/en.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", pulls[0].number),
         true,
@@ -124,7 +124,7 @@ async fn test_one_pull_and_conflict_one_comment() {
 
     c.github
         .test_update_pull("test/repo", pulls[0].number, &["wiki/Other_article/en.md"]);
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", pulls[0].number),
         true,
@@ -151,7 +151,7 @@ async fn test_one_pull_and_conflict_one_comment_updated() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -165,7 +165,7 @@ async fn test_one_pull_and_conflict_one_comment_updated() {
         pulls[0].number,
         &["wiki/Article/en.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", pulls[0].number),
         true,
@@ -175,7 +175,7 @@ async fn test_one_pull_and_conflict_one_comment_updated() {
 
     c.github
         .test_update_pull("test/repo", pulls[0].number, &["wiki/Other_article/en.md"]);
-    c.add_pull(
+    c.upsert_pull(
         "test/repo",
         c.github.fetch_pull("test/repo", pulls[0].number),
         true,
@@ -223,7 +223,7 @@ async fn test_post_comment_per_pull_and_conflict_combination() {
             .test_add_pull("test/repo", &["wiki/New_article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -275,7 +275,7 @@ async fn test_obsolete_comment_is_removed() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -286,7 +286,7 @@ async fn test_obsolete_comment_is_removed() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Article_2/ru.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
         .await
         .unwrap();
     assert!(c
@@ -311,7 +311,7 @@ async fn test_only_target_comment_is_removed() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -327,7 +327,7 @@ async fn test_only_target_comment_is_removed() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Article/Other_article/en.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
         .await
         .unwrap();
 
@@ -351,7 +351,7 @@ async fn test_new_comment_is_posted_after_removal_in_different_pull() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -369,7 +369,7 @@ async fn test_new_comment_is_posted_after_removal_in_different_pull() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Article/Other_article/en.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
         .await
         .unwrap();
 
@@ -382,7 +382,7 @@ async fn test_new_comment_is_posted_after_removal_in_different_pull() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Article/ru.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), true)
         .await
         .unwrap();
 

--- a/src/controller/controller_impl/tests/tests_conflicts.rs
+++ b/src/controller/controller_impl/tests/tests_conflicts.rs
@@ -10,7 +10,7 @@ async fn test_add_pull() {
     p.diff = None;
     let pn = p.number;
 
-    c.add_pull("test/repo", p, false).await.unwrap();
+    c.upsert_pull("test/repo", p, false).await.unwrap();
 
     let m = c.memory.pulls("test/repo");
     assert!(m.is_some());
@@ -25,7 +25,7 @@ async fn test_simple_overlap_originals() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     assert!(c.conflicts.by_trigger("test/repo", 1).is_empty());
@@ -48,7 +48,7 @@ async fn test_simple_overlap_translations() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     assert!(c.conflicts.by_trigger("test/repo", 1).is_empty());
@@ -71,7 +71,7 @@ async fn test_different_translations_do_not_overlap() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ko.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     assert!(c.conflicts.by_trigger("test/repo", 1).is_empty());
@@ -86,7 +86,7 @@ async fn test_simple_early_incomplete_translation() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     assert_eq!(
@@ -109,7 +109,7 @@ async fn test_simple_late_incomplete_translation() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     assert!(&c.conflicts.by_trigger("test/repo", 1).is_empty());
@@ -134,7 +134,7 @@ async fn test_multiple_overlapping_changes() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     let overlap = |trigger, original| {
@@ -171,7 +171,7 @@ async fn test_multiple_incomplete_translations() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     let incomplete_translation = |trigger, original| {
@@ -208,7 +208,7 @@ async fn test_incomplete_translation_multiple_conflicts() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ko.md"]),
     ];
     for p in pulls {
-        c.add_pull("test/repo", p, false).await.unwrap();
+        c.upsert_pull("test/repo", p, false).await.unwrap();
     }
 
     let incomplete_translation_conflict = |trigger, original| {
@@ -243,7 +243,7 @@ async fn test_overlap_no_extra_files_on_update() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull("test/repo", p.clone(), false).await.unwrap();
+        c.upsert_pull("test/repo", p.clone(), false).await.unwrap();
     }
 
     c.github.test_update_pull(
@@ -251,7 +251,7 @@ async fn test_overlap_no_extra_files_on_update() {
         1,
         &["wiki/Article/ru.md", "wiki/Other_article/ru.md"],
     );
-    c.add_pull("test/repo", pulls[0].clone(), false)
+    c.upsert_pull("test/repo", pulls[0].clone(), false)
         .await
         .unwrap();
 
@@ -278,7 +278,7 @@ async fn test_overlap_file_set_update_in_trigger_recognized() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull("test/repo", p.clone(), false).await.unwrap();
+        c.upsert_pull("test/repo", p.clone(), false).await.unwrap();
     }
 
     c.github.test_update_pull(
@@ -286,7 +286,7 @@ async fn test_overlap_file_set_update_in_trigger_recognized() {
         1,
         &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", pulls[0].clone(), false)
+    c.upsert_pull("test/repo", pulls[0].clone(), false)
         .await
         .unwrap();
 
@@ -313,7 +313,7 @@ async fn test_overlap_double_update_recognized() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -327,7 +327,7 @@ async fn test_overlap_double_update_recognized() {
         1,
         &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
         .await
         .unwrap();
     c.github.test_update_pull(
@@ -335,7 +335,7 @@ async fn test_overlap_double_update_recognized() {
         2,
         &["wiki/Article/ru.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
         .await
         .unwrap();
 
@@ -362,7 +362,7 @@ async fn test_early_incomplete_translation_update_no_unrelated_files() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -376,7 +376,7 @@ async fn test_early_incomplete_translation_update_no_unrelated_files() {
         2,
         &["wiki/Article/en.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
         .await
         .unwrap();
 
@@ -403,7 +403,7 @@ async fn test_incomplete_translation_original_update_recognized() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -417,7 +417,7 @@ async fn test_incomplete_translation_original_update_recognized() {
         2,
         &["wiki/Article/en.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
         .await
         .unwrap();
 
@@ -444,7 +444,7 @@ async fn test_incomplete_translation_double_update() {
         c.github.test_add_pull("test/repo", &["wiki/Article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -458,7 +458,7 @@ async fn test_incomplete_translation_double_update() {
         1,
         &["wiki/Article/ru.md", "wiki/Other_article/ru.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
         .await
         .unwrap();
     c.github.test_update_pull(
@@ -466,7 +466,7 @@ async fn test_incomplete_translation_double_update() {
         2,
         &["wiki/Article/en.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
         .await
         .unwrap();
 
@@ -493,7 +493,7 @@ async fn test_late_incomplete_translation_update_no_extra_files() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -507,7 +507,7 @@ async fn test_late_incomplete_translation_update_no_extra_files() {
         1,
         &["wiki/Article/en.md", "wiki/Other_article/en.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
         .await
         .unwrap();
 
@@ -534,7 +534,7 @@ async fn test_incomplete_translation_update_recognized() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -548,7 +548,7 @@ async fn test_incomplete_translation_update_recognized() {
         2,
         &["wiki/Article/ru.md", "wiki/Other_article/ru.md"],
     );
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 2), false)
         .await
         .unwrap();
 
@@ -576,7 +576,7 @@ async fn test_outdated_translation_produces_single_conflict() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -616,7 +616,7 @@ async fn test_three_conflicts_at_once() {
             .test_add_pull("test/repo", &["wiki/Different_article/en.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -656,7 +656,7 @@ async fn test_closed_pull_is_removed() {
     let pull = c
         .github
         .test_add_pull("test/repo", &["wiki/Article/en.md", "wiki/Article_2/ru.md"]);
-    c.add_pull("test/repo", pull, true).await.unwrap();
+    c.upsert_pull("test/repo", pull, true).await.unwrap();
 
     c.remove_pull("test/repo", c.github.fetch_pull("test/repo", 1));
     assert!(c.memory.pulls("test/repo").unwrap().is_empty());
@@ -676,7 +676,7 @@ async fn test_closed_pull_conflicts_removed() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -699,7 +699,7 @@ async fn test_closed_pull_related_conflicts_removed() {
         c.github.test_add_pull("test/repo", &["wiki/Article/zh.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             true,
@@ -723,7 +723,7 @@ async fn test_obsolete_conflict_removed() {
         c.github.test_add_pull("test/repo", &["wiki/Article/ru.md"]),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -734,7 +734,7 @@ async fn test_obsolete_conflict_removed() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Other_article/ru.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
         .await
         .unwrap();
 
@@ -756,7 +756,7 @@ async fn test_only_obsolete_conflict_is_removed_overlap() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -767,7 +767,7 @@ async fn test_only_obsolete_conflict_is_removed_overlap() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Article/Other_article/en.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
         .await
         .unwrap();
 
@@ -796,7 +796,7 @@ async fn test_only_obsolete_conflict_is_removed_incomplete_translation() {
         ),
     ];
     for p in pulls.iter() {
-        c.add_pull(
+        c.upsert_pull(
             "test/repo",
             c.github.fetch_pull("test/repo", p.number),
             false,
@@ -807,7 +807,7 @@ async fn test_only_obsolete_conflict_is_removed_incomplete_translation() {
 
     c.github
         .test_update_pull("test/repo", 1, &["wiki/Article/ru.md"]);
-    c.add_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
+    c.upsert_pull("test/repo", c.github.fetch_pull("test/repo", 1), false)
         .await
         .unwrap();
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -14,6 +14,11 @@ pub enum ControllerRequest {
         reply_to: oneshot::Sender<Result<()>>,
     },
 
+    PullRequestCreated {
+        full_repo_name: String,
+        pull_request: Box<PullRequest>,
+        trigger_updates: bool,
+    },
     PullRequestUpdated {
         full_repo_name: String,
         pull_request: Box<PullRequest>,
@@ -76,6 +81,20 @@ impl ControllerHandle {
     }
 
     pub async fn add_pull(
+        &self,
+        full_repo_name: &str,
+        pull_request: PullRequest,
+        trigger_updates: bool,
+    ) {
+        let msg = ControllerRequest::PullRequestCreated {
+            full_repo_name: full_repo_name.to_owned(),
+            pull_request: Box::new(pull_request),
+            trigger_updates,
+        };
+        self.sender.send(msg).await.unwrap();
+    }
+
+    pub async fn update_pull(
         &self,
         full_repo_name: &str,
         pull_request: PullRequest,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,9 +20,14 @@ pub async fn pull_request_event(req: Request, body: String) -> viz::Result<()> {
     let pull_number = evt.pull_request.number;
     log::debug!("Pull #{}: received event \"{}\"", pull_number, evt.action);
     match evt.action.as_str() {
-        "synchronize" | "opened" | "reopened" => {
+        "opened" | "reopened" => {
             controller_handle
                 .add_pull(&evt.repository.full_name, evt.pull_request, true)
+                .await;
+        }
+        "synchronize" => {
+            controller_handle
+                .update_pull(&evt.repository.full_name, evt.pull_request, true)
                 .await;
         }
         "closed" => {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -16,6 +16,12 @@ impl Memory {
         Self::default()
     }
 
+    pub fn contains(&self, full_repo_name: &str, pr: &PullRequest) -> bool {
+        let g = self.pulls.lock().unwrap();
+        g.get(full_repo_name)
+            .map_or(false, |pulls| pulls.contains_key(&pr.number))
+    }
+
     pub fn insert_pull(&self, full_repo_name: &str, new_pull: PullRequest) {
         let mut g = self.pulls.lock().unwrap();
         if let Some(pull) = g


### PR DESCRIPTION
I hope GitHub doesn't lose open events, ever, or pulls may be ignored on rare occasions
resolves https://github.com/TicClick/observatory/issues/10