### PR TITLE
Load closed PRs' diffs before resolving their conflicts

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -36,7 +36,7 @@ pub struct PullRequest {
 
     #[serde(default)]
     pub merged_at: Option<chrono::DateTime<chrono::Utc>>,
-    
+
     #[serde(default)]
     pub merged: bool,
 }


### PR DESCRIPTION
crash introduced in https://github.com/TicClick/observatory/pull/23